### PR TITLE
Fix for PlayJobsService.java class loader bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ lib
 eclipse
 modules
 dist
+*.pyc
+*~

--- a/README.textile
+++ b/README.textile
@@ -14,8 +14,9 @@ http://playjobs.mashup.fm
 Install Locally
 - Install Module
 -- git clone play-jobs into a local directory separate from your play app
+-- type "play build-module" to build the module. Enter "1.2" or so for required version
 -- look for instructions on how to set up references to local modules, such as
--- http://stackoverflow.com/questions/5859037/how-to-reference-local-modules-using-dependency-yml
+--- http://stackoverflow.com/questions/5859037/how-to-reference-local-modules-using-dependency-yml
 - Add module routes to the application that's installing the jobs module
 -- see instructions in play-jobs/conf/routes
 - Start your play application

--- a/README.textile
+++ b/README.textile
@@ -13,7 +13,11 @@ http://playjobs.mashup.fm
 
 Install Locally
 - Install Module
+-- git clone play-jobs into a local directory separate from your play app
+-- look for instructions on how to set up references to local modules, such as
+-- http://stackoverflow.com/questions/5859037/how-to-reference-local-modules-using-dependency-yml
 - Add module routes to the application that's installing the jobs module
+-- see instructions in play-jobs/conf/routes
 - Start your play application
 - In your browser, go to http://localhost:9000/@jobs
 

--- a/conf/routes
+++ b/conf/routes
@@ -3,6 +3,9 @@
 # import these routes in the main app as :
 # *     /                       module:jobs
 #
+# then, in play 1.2.4+ it may be necessary to put the following after your exisiting static dir 
+# GET     /play-jobs/             staticDir:public-play-jobs
+#
 # ~~~~
 
 GET     /?                      PlayJobsDashboard.index

--- a/src/play/modules/jobs/PlayJobsService.java
+++ b/src/play/modules/jobs/PlayJobsService.java
@@ -120,7 +120,7 @@ public class PlayJobsService {
 		// Trigger Job(s)
 		try {
 			// Define Class
-			Class clazz = Class.forName(jobClass);
+			Class clazz = Play.classloader.getClassIgnoreCase(jobClass);
 			if (clazz == null) {
 				throw new RuntimeException("Invalid Job Class: " + jobClass);
 			}


### PR DESCRIPTION
Hi,

Thanks for providing this nice front-end!

I found that  Class.forName(jobClass); resulted in a class not found exception on play 1.2.4 on a mac. Reasoning that the plugin was able to find the class with the play classloader, I fixed it with Play.classloader.getClassIgnoreCase(jobClass);. 

I have also added some separate commits which I think improve the documentation which you are welcome to accept or reject.

Do you have any ticket tracking for potential features? I think it would be nice if the front end kept track of a history of which jobs were requested when and their current status - not sure if there is a simple mechanism for long running jobs to provide status updates.

Best,
Alok
