### PR TITLE
setting dependency to play 1.x

### DIFF
--- a/conf/dependencies.yml
+++ b/conf/dependencies.yml
@@ -1,7 +1,7 @@
 self: play -> jobs 0.2
 
 require:
-    - play
+    - play 1.+
     - play -> resteasy 1.3.1
     - org.jboss.resteasy -> resteasy-jaxrs 2.1.0.GA
     - org.jboss.resteasy -> resteasy-jaxb-provider 2.1.0.GA


### PR DESCRIPTION
this will avoid the need to enter the play version during `play build-module`
